### PR TITLE
Fixed, and now runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ This short Python script allows you to easily switch the resolution of your main
  2. Setup a virtual environment inside of the repository: `python -m venv .venv`
  3. Activate the environment: `.\.venv\Scripts\activate`
  4. Install the required Python packages: `python -m pip install -r requirements.txt`
- ~~5. Add your Resolutions: In the file [resolution_switcher.py](./resolution_switcher.py) you find the `menu` tuple and it's `item`s. Here you can add your custom resolution by either adding another `item` or editing the existing ones that call `on_set_resolution(width, height)`.~~
- ~~6. Change the path to the repository in [resolution_switcher.bat](resolution_switcher.bat). The path after the `cd` command enclosed by `"` has to be changed to the path of this repository on your computer.~~
+ 5. ~~Add your Resolutions: In the file [resolution_switcher.py](./resolution_switcher.py) you find the `menu` tuple and it's `item`s. Here you can add your custom resolution by either adding another `item` or editing the existing ones that call `on_set_resolution(width, height)`.~~
+ 6. ~~Change the path to the repository in [resolution_switcher.bat](resolution_switcher.bat). The path after the `cd` command enclosed by `"` has to be changed to the path of this repository on your computer.~~
  8. Check if it works by double-clicking on [resolution_switcher.vbs](./resolution_switcher.vbs) and right-clicking on the **RS** icon in the system tray.
  9. Create a shortcut for [resolution_switcher.vbs](./resolution_switcher.vbs)
  10. Add the shortcut to the Windows startup: Press **Win+R** and enter `shell:startup` and move the created shortcut into the newly opened folder in the Explorer.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ This short Python script allows you to easily switch the resolution of your main
  2. Setup a virtual environment inside of the repository: `python -m venv .venv`
  3. Activate the environment: `.\.venv\Scripts\activate`
  4. Install the required Python packages: `python -m pip install -r requirements.txt`
- 5. Add your Resolutions: In the file [resolution_switcher.py](./resolution_switcher.py) you find the `menu` tuple and it's `item`s. Here you can add your custom resolution by either adding another `item` or editing the existing ones that call `on_set_resolution(width, height)`.
- 6. Change the path to the repository in [resolution_switcher.bat](resolution_switcher.bat). The path after the `cd` command enclosed by `"` has to be changed to the path of this repository on your computer.
+ ~~5. Add your Resolutions: In the file [resolution_switcher.py](./resolution_switcher.py) you find the `menu` tuple and it's `item`s. Here you can add your custom resolution by either adding another `item` or editing the existing ones that call `on_set_resolution(width, height)`.~~
+ ~~6. Change the path to the repository in [resolution_switcher.bat](resolution_switcher.bat). The path after the `cd` command enclosed by `"` has to be changed to the path of this repository on your computer.~~
  8. Check if it works by double-clicking on [resolution_switcher.vbs](./resolution_switcher.vbs) and right-clicking on the **RS** icon in the system tray.
  9. Create a shortcut for [resolution_switcher.vbs](./resolution_switcher.vbs)
  10. Add the shortcut to the Windows startup: Press **Win+R** and enter `shell:startup` and move the created shortcut into the newly opened folder in the Explorer.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pystray~=0.19.4
-pywin32~=303
+pywin32>=303

--- a/resolution_switcher.bat
+++ b/resolution_switcher.bat
@@ -1,1 +1,17 @@
-cd "C:\Users\konze\Programming\windows_resolution_switcher" & .\.venv\Scripts\activate & pythonw resolution_switcher.py
+@echo off
+set SCRIPT_DIR=%~dp0
+cd "%SCRIPT_DIR%"
+
+:: Define the path to the virtual environment's python executable
+set PYTHON_EXE="%SCRIPT_DIR%\.venv\Scripts\pythonw.exe"
+
+:: Check if the python executable exists
+if not exist %PYTHON_EXE% (
+    echo Error: Python executable not found at %PYTHON_EXE%
+    echo Please ensure the virtual environment is set up correctly.
+    pause
+    exit /b 1
+)
+
+:: Execute the Python script using the full path to the venv's pythonw
+%PYTHON_EXE% resolution_switcher.py

--- a/resolution_switcher.vbs
+++ b/resolution_switcher.vbs
@@ -1,3 +1,3 @@
 Set WshShell = CreateObject("WScript.Shell") 
-WshShell.Run chr(34) & "resolution_switcher.bat" & Chr(34), 0
+WshShell.Run Chr(34) & "resolution_switcher.bat" & Chr(34), 0
 Set WshShell = Nothing


### PR DESCRIPTION
Fixed everything that prevented it from installing and running. Requirement for pywin32 changed to >=303.
BAT file selects directory automatically and uses python executable inside our virtual environment (it didn't work at all without that last step).

On directions: manually setting resolutions is not needed, and directions should reflect that.